### PR TITLE
feat: support multiple address per dataset

### DIFF
--- a/daemon/datasets.go
+++ b/daemon/datasets.go
@@ -15,7 +15,7 @@ import (
 
 type Dataset struct {
 	Dataset             string          `json:"dataset"`
-	Address             string          `json:"address"`
+	Addresses           []string        `json:"address"`
 	Dir                 string          `json:"dir"`
 	Ignore              bool            `json:"ignore,omitempty"`
 	alreadyImportedCids map[string]bool `json:"omitempty"`
@@ -86,7 +86,13 @@ func (d *Dataset) PopulateAlreadyImportedCids(boost *svc.BoostConnection) {
 		return
 	}
 
-	completedDeals := boost.GetDealsCompleted(d.Address)
+	var completedDeals svc.BoostDeals
+
+	for _, addr := range d.Addresses {
+		cd := boost.GetDealsCompleted(addr)
+		completedDeals = append(completedDeals, cd...)
+
+	}
 	log.Debugf("found %d completed deals for dataset %s", len(completedDeals), d.Dataset)
 
 	for _, deal := range completedDeals {

--- a/daemon/importer.go
+++ b/daemon/importer.go
@@ -58,7 +58,7 @@ func importer(cfg Config, db *db.DIDB, datasets map[string]Dataset) {
 var cidsAlreadyAttempted = make(map[string]bool)
 
 func importerDefault(cfg Config, ds Dataset, boost *svc.BoostConnection) *svc.ImportResult {
-	toImport := boost.GetDealsAwaitingImport(ds.Address)
+	toImport := boost.GetDealsAwaitingImport(ds.Addresses)
 
 	if len(toImport) == 0 {
 		log.Debugf("skipping dataset %s : no deals awaiting import", ds.Dataset)

--- a/readme.md
+++ b/readme.md
@@ -92,13 +92,13 @@ Example `datasets.json`
 [
   {
     "dataset": "radiant-ml",
-    "address": "f1p3l3wgnfukemmaupqecwcoqp7fcgjcqgqcq7rja",
+    "address": ["f1p3l3wgnfukemmaupqecwcoqp7fcgjcqgqcq7rja"],
     "dir": "/mnt/delta-datasets/radiant-poc",
     "ignore": false
   },
   {
     "dataset": "cancer-imaging-archive",
-    "address": "f1p3l3wgnfukemmaupqecwcoqp7fcgjcqgqcq7rja",
+    "address": ["f1p3l3wgnfukemmaupqecwcoqp7fcgjcqgqcq7rja", "f2vyp7qmi4pvuj3f3qiha6oyskrjdho2xw6cjiexi"],
     "dir": "/mnt/delta-datasets/cancer-imaging-archive",
     "ignore": true
   }


### PR DESCRIPTION
closes #19 

Note: This change is not backwards compatible with the old version of the `datasets.json` file.

You must enclose the `address` field in square brackets to make it a list, ex:

**OLD datasets.json**
```json
[
  {
    "dataset": "radiant-ml",
    "address": "f1p3l3wgnfukemmaupqecwcoqp7fcgjcqgqcq7rja",
    "dir": "/mnt/delta-datasets/radiant-poc",
    "ignore": false
  }
]
```

**UPDATED datasets.json**
```jsonc
[
  {
    "dataset": "radiant-ml",
    "address": ["f1p3l3wgnfukemmaupqecwcoqp7fcgjcqgqcq7rja"], // <- wrap in [ ]
    "dir": "/mnt/delta-datasets/radiant-poc",
    "ignore": false
  }
]
```